### PR TITLE
set bg transparent to allow picture behind Sketch

### DIFF
--- a/lib/components/Sketch.js
+++ b/lib/components/Sketch.js
@@ -184,8 +184,8 @@ export default class Sketch extends React.Component<Props> {
       {
         context,
         antialias: true,
-        backgroundColor: 0xffffff,
-        transparent: false,
+        backgroundColor: transparent,
+        transparent: true,
         autoStart: false,
       }
     );


### PR DESCRIPTION
set transparent background to allow picture behind Sketch Component